### PR TITLE
[#31] fix for mobile nav height blocked by ios mobile bottom nav

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -134,9 +134,9 @@ header nav.mobile-menu {
   grid-template:
     "hamburger brand" var(--nav-height)
     "sections sections" 1fr
-    "cta cta" 15vh / auto 1fr;
+    "cta cta" 12.5vh / auto 1fr;
   overflow-y: auto;
-  min-height: 100vh;
+  min-height: 100%;
 }
 
 @media (max-width: 899px) {


### PR DESCRIPTION
Fix for mobile nav blocked by ios mobile bottom nav, related to #31 

Test URLs:
- Before: https://main--tbx-intr--tbx-co.hlx.page/
- After: https://feature-about-and-contact--tbx-intr--tbx-co.hlx.page/